### PR TITLE
Fix 1 vulnerable dependencies identified by Prisma Cloud

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.10.2</version>
+      <version>2.16.0</version>
     </dependency> -->
 
          <!-- remove  ^^^ for the demo -->


### PR DESCRIPTION
Prisma Cloud has detected new vulnerabilities or dependencies in the scan performed on Thu, 11 Jan 2024 10:27:27 UTC

**This PR includes the fixes for the vulnerabilities discovered below:**
Severity | Dependency File | Package name | CVE | Risk Score | Fix Status | Description
-- | -- | -- | -- | -- | -- | --
critical | license/package-lock.json | cached-path-relative | [CVE-2021-23518](https://nvd.nist.gov/vuln/detail/CVE-2021-23518) | 9.8 | fixed in 1.1.0 | The package cached-path-relative before 1.1.0 are vulnerable to Prototype Pollution via the cache variable that is set as {} instead of Object.create(null) in the cachedPathRelative function, which allows access to the parent prototype properties when the object is used to create the cached relative path. When using the origin path as __proto__, the attribute of the object is accessed instead of a path. **Note:** This vulnerability derives from an incomplete fix in https://security.snyk.io/vuln/SNYK-JS-CACHEDPATHRELATIVE-72573
critical | license/package-lock.json | mpath | [CVE-2021-23438](https://nvd.nist.gov/vuln/detail/CVE-2021-23438) | 9.8 | fixed in 0.8.4 | This affects the package mpath before 0.8.4. A type confusion vulnerability can lead to a bypass of CVE-2018-16490. In particular, the condition ignoreProperties.indexOf(parts[i]) !== -1 returns -1 if parts[i] is [\'__proto__\']. This is because the method that has been called if the input is an array is Array.prototype.indexOf() and not String.prototype.indexOf(). They behave differently depending on the type of the input.
critical | license/package-lock.json | ejs | [CVE-2017-1000228](https://nvd.nist.gov/vuln/detail/CVE-2017-1000228) | 9.8 | fixed in 2.5.5 | nodejs ejs versions older than 2.5.3 is vulnerable to remote code execution due to weak input validation in ejs.renderFile() function
critical | license/package-lock.json | ini | [CVE-2020-7788](https://nvd.nist.gov/vuln/detail/CVE-2020-7788) | 9.8 | fixed in 1.3.6 | This affects the package ini before 1.3.6. If an attacker submits a malicious INI file to an application that parses it with ini.parse, they will pollute the prototype on the application. This can be exploited further depending on the context.
critical | license/package-lock.json | minimist | [CVE-2021-44906](https://nvd.nist.gov/vuln/detail/CVE-2021-44906) | 9.8 | fixed in 1.2.6 | Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).
critical | license/package-lock.json | lodash | [CVE-2019-10744](https://nvd.nist.gov/vuln/detail/CVE-2019-10744) | 9.1 | fixed in 4.17.12 | Versions of lodash lower than 4.17.12 are vulnerable to Prototype Pollution. The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.
critical | license/package-lock.json | shell-quote | [CVE-2021-42740](https://nvd.nist.gov/vuln/detail/CVE-2021-42740) | 9.8 | fixed in 1.7.3 | The shell-quote package before 1.7.3 for Node.js allows command injection. An attacker can inject unescaped shell metacharacters through a regex designed to support Windows drive letters. If the output of this package is passed to a real shell as a quoted argument to a command with exec(), an attacker can inject arbitrary commands. This is because the Windows drive letter regex character class is {A-z] instead of the correct {A-Za-z]. Several shell metacharacters exist in the space between capital letter Z and lower case letter a, such as the backtick character.
critical | license/package-lock.json | y18n | [CVE-2020-7774](https://nvd.nist.gov/vuln/detail/CVE-2020-7774) | 9.8 | fixed in 5.0.5, 4.0.1, 3.2.2 | The package y18n before 3.2.2, 4.0.1 and 5.0.5, is vulnerable to Prototype Pollution.
critical | license/package-lock.json | parse-url | [CVE-2022-2900](https://nvd.nist.gov/vuln/detail/CVE-2022-2900) | 9.1 | fixed in 8.1.0 | Server-Side Request Forgery (SSRF) in GitHub repository ionicabizau/parse-url prior to 8.1.0.
critical | license/package-lock.json | parse-url | [CVE-2022-2216](https://nvd.nist.gov/vuln/detail/CVE-2022-2216) | 9.8 | fixed in 6.0.1 | Server-Side Request Forgery (SSRF) in GitHub repository ionicabizau/parse-url prior to 7.0.0.
critical | license/package-lock.json | json-schema | [CVE-2021-3918](https://nvd.nist.gov/vuln/detail/CVE-2021-3918) | 9.8 | fixed in 0.4.0 | json-schema is vulnerable to Improperly Controlled Modification of Object Prototype Attributes (\'Prototype Pollution\')
critical | license/package-lock.json | mongoose | [CVE-2023-3696](https://nvd.nist.gov/vuln/detail/CVE-2023-3696) | 9.8 | fixed in 7.3.4, 6.11.3, 5.13.20 | Prototype Pollution in GitHub repository automattic/mongoose prior to 7.3.4.
critical | license/package-lock.json | mongoose | [CVE-2022-2564](https://nvd.nist.gov/vuln/detail/CVE-2022-2564) | 9.8 | fixed in 6.4.6 | Prototype Pollution in GitHub repository automattic/mongoose prior to 6.4.6.
critical | license/package-lock.json | express-fileupload | [CVE-2020-7699](https://nvd.nist.gov/vuln/detail/CVE-2020-7699) | 9.8 | fixed in 1.1.9 | This affects the package express-fileupload before 1.1.8. If the parseNested option is enabled, sending a corrupt HTTP request can lead to denial of service or arbitrary code execution.
critical | license/package-lock.json | tough-cookie | [CVE-2023-26136](https://nvd.nist.gov/vuln/detail/CVE-2023-26136) | 9.8 | fixed in 4.1.3 | Versions of the package tough-cookie before 4.1.3 are vulnerable to Prototype Pollution due to improper handling of Cookies when using CookieJar in rejectPublicSuffixes=false mode. This issue arises from the manner in which the objects are initialized.
critical | license/package-lock.json | typeorm | [CVE-2020-8158](https://nvd.nist.gov/vuln/detail/CVE-2020-8158) | 9.8 | fixed in 0.2.25 | Prototype pollution vulnerability in the TypeORM package < 0.2.25 may allow attackers to add or modify Object properties leading to further denial of service or SQL injection attacks.
critical | license/package-lock.json | typeorm | [CVE-2022-33171](https://nvd.nist.gov/vuln/detail/CVE-2022-33171) | 9.8 | fixed in 0.3.0 | The findOne function in TypeORM before 0.3.0 can either be supplied with a string or a FindOneOptions object. When input to the function is a user-controlled parsed JSON object, supplying a crafted FindOneOptions instead of an id string leads to SQL injection. NOTE: the vendor\'s position is that the user\'s application is responsible for input validation
critical | license/package-lock.json | pac-resolver | [CVE-2021-23406](https://nvd.nist.gov/vuln/detail/CVE-2021-23406) | 9.8 | fixed in 5.0.0 | This affects the package pac-resolver before 5.0.0. This can occur when used with untrusted input, due to unsafe PAC file handling. **NOTE:** The fix for this vulnerability is applied in the node-degenerator library, a dependency written by the same maintainer.
high | license/package-lock.json | underscore | [CVE-2021-23358](https://nvd.nist.gov/vuln/detail/CVE-2021-23358) | 7.2 | fixed in 1.13.0-2, 1.12.1 | The package underscore from 1.13.0-0 and before 1.13.0-2, from 1.3.2 and before 1.12.1 are vulnerable to Arbitrary Code Injection via the template function, particularly when a variable property is passed as an argument as it is not sanitized.
high | license/package-lock.json | marked | [CVE-2022-21681](https://nvd.nist.gov/vuln/detail/CVE-2022-21681) | 7.5 | fixed in 4.0.10 | Marked is a markdown parser and compiler. Prior to version 4.0.10, the regular expression `inline.reflinkSearch` may cause catastrophic backtracking against some strings and lead to a denial of service (DoS). Anyone who runs untrusted markdown through a vulnerable version of marked and does not use a worker with a time limit may be affected. This issue is patched in version 4.0.10. As a workaround, avoid running untrusted markdown through marked or run marked on a worker thread and set a reasonable time limit to prevent draining resources.
high | license/package-lock.json | marked | [CVE-2022-21680](https://nvd.nist.gov/vuln/detail/CVE-2022-21680) | 7.5 | fixed in 4.0.10 | Marked is a markdown parser and compiler. Prior to version 4.0.10, the regular expression `block.def` may cause catastrophic backtracking against some strings and lead to a regular expression denial of service (ReDoS). Anyone who runs untrusted markdown through a vulnerable version of marked and does not use a worker with a time limit may be affected. This issue is patched in version 4.0.10. As a workaround, avoid running untrusted markdown through marked or run marked on a worker thread and set a reasonable time limit to prevent draining resources.
high | license/package-lock.json | marked | [CVE-2017-16114](https://nvd.nist.gov/vuln/detail/CVE-2017-16114) | 7.5 | fixed in 0.3.9 | The marked module is vulnerable to a regular expression denial of service. Based on the information published in the public issue, 1k characters can block for around 6 seconds.
high | license/package-lock.json | diff | [GHSA-h6ch-v84p-w6p9](https://github.com/advisories/GHSA-h6ch-v84p-w6p9) | 7.0 | fixed in 3.5.0 | A vulnerability was found in diff before v3.5.0, the affected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.
high | license/package-lock.json | highlight.js | [CVE-2020-26237](https://nvd.nist.gov/vuln/detail/CVE-2020-26237) | 8.7 | fixed in 10.1.2, 9.18.2 | Highlight.js is a syntax highlighter written in JavaScript. Highlight.js versions before 9.18.2 and 10.1.2 are vulnerable to Prototype Pollution. A malicious HTML code block can be crafted that will result in prototype pollution of the base object\'s prototype during highlighting. If you allow users to insert custom HTML code blocks into your page/app via parsing Markdown code blocks (or similar) and do not filter the language names the user can provide you may be vulnerable. The pollution should just be harmless data but this can cause problems for applications not expecting these properties to exist and can result in strange behavior or application crashes, i.e. a potential DOS vector. If your website or application does not render user provided data it should be unaffected. Versions 9.18.2 and 10.1.2 and newer include fixes for this vulnerability. If you are using version 7 or 8 you are encouraged to upgrade to a newer release.
high | license/package-lock.json | mime | [CVE-2017-16138](https://nvd.nist.gov/vuln/detail/CVE-2017-16138) | 7.5 | fixed in 2.0.3, 1.4.1 | The mime module < 1.4.1, 2.0.1, 2.0.2 is vulnerable to regular expression denial of service when a mime lookup is performed on untrusted user input.
high | license/package-lock.json | snyk | [CVE-2022-24441](https://nvd.nist.gov/vuln/detail/CVE-2022-24441) | 8.8 | fixed in 1.1064.0 | The package snyk before 1.1064.0 are vulnerable to Code Injection when analyzing a project. An attacker who can convince a user to scan a malicious project can include commands in a build file such as build.gradle or gradle-wrapper.jar, which will be executed with the privileges of the application. This vulnerability may be triggered when running the the CLI tool directly, or when running a scan with one of the IDE plugins that invoke the Snyk CLI. Successful exploitation of this issue would likely require some level of social engineering - to coerce an untrusted project to be downloaded and analyzed via the Snyk CLI or opened in an IDE where a Snyk IDE plugin is installed and enabled. Additionally, if the IDE has a Trust feature then the target folder must be marked as ‘trusted’ in order to be vulnerable. **NOTE:** This issue is independent of the one reported in [CVE-2022-40764](https://security.snyk.io/vuln/SNYK-JS-SNYK-3037342), and upgrading to a fixed version for this addresses that issue as well. The affected IDE plugins and versions are: - VS Code - Affected: <=1.8.0, Fixed: 1.9.0 - IntelliJ - Affected: <=2.4.47, Fixed: 2.4.48 - Visual Studio - Affected: <=1.1.30, Fixed: 1.1.31 - Eclipse - Affected: <=v20221115.132308, Fixed: All subsequent versions - Language Server - Affected: <=v20221109.114426, Fixed: All subsequent versions
high | license/package-lock.json | snyk | [CVE-2022-40764](https://nvd.nist.gov/vuln/detail/CVE-2022-40764) | 7.8 | fixed in 1.996.0 | Snyk CLI before 1.996.0 allows arbitrary command execution, affecting Snyk IDE plugins and the snyk npm package. Exploitation could follow from the common practice of viewing untrusted files in the Visual Studio Code editor, for example. The original demonstration was with shell metacharacters in the vendor.json ignore field, affecting snyk-go-plugin before 1.19.1. This affects, for example, the Snyk TeamCity plugin (which does not update automatically) before 20220930.142957.
high | license/package-lock.json | mpath | [CVE-2018-16490](https://nvd.nist.gov/vuln/detail/CVE-2018-16490) | 7.5 | fixed in 0.5.1 | A prototype pollution vulnerability was found in module mpath <0.5.1 that allows an attacker to inject arbitrary properties onto Object.prototype.
high | license/package-lock.json | tap-mocha-reporter | [PRISMA-2022-0098](https://github.com/tapjs/tap-mocha-reporter/commit/57529706c268b81652297c82f55ed5e7dfc8a3b2) | 8.0 | fixed in 5.0.2 | tap-mocha-reporter package versions before 5.0.2 are vulnerable to Prototype Pollution.  This package allows for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE
high | license/package-lock.json | word-wrap | [CVE-2023-26115](https://nvd.nist.gov/vuln/detail/CVE-2023-26115) | 7.5 | fixed in 1.2.4 | All versions of the package word-wrap are vulnerable to Regular Expression Denial of Service (ReDoS) due to the usage of an insecure regular expression within the result variable.\r\r
high | license/package-lock.json | qs | [CVE-2022-24999](https://nvd.nist.gov/vuln/detail/CVE-2022-24999) | 7.5 | fixed in 6.10.3 | qs before 6.10.3, as used in Express before 4.17.3 and other products, allows attackers to cause a Node process hang for an Express application because an __ proto__ key can be used. In many typical Express use cases, an unauthenticated remote attacker can place the attack payload in the query string of the URL that is used to visit the application, such as a[__proto__]=b&a[__proto__]&a[length]=100000000. The fix was backported to qs 6.9.7, 6.8.3, 6.7.3, 6.6.1, 6.5.3, 6.4.1, 6.3.3, and 6.2.4 (and therefore Express 4.17.3, which has \"deps: qs@6.9.7\" in its release description, is not vulnerable).
high | license/package-lock.json | qs | [CVE-2017-1000048](https://nvd.nist.gov/vuln/detail/CVE-2017-1000048) | 7.5 | fixed in 6.3.2, 6.2.3, 6.1.2, 6.0.4 | the web framework using ljharb\'s qs module older than v6.3.2, v6.2.3, v6.1.2, and v6.0.4 is vulnerable to a DoS. A malicious user can send a evil request to cause the web framework crash.
high | license/package-lock.json | acorn | [GHSA-6chw-6frg-f759](https://github.com/advisories/GHSA-6chw-6frg-f759) | 7.5 | fixed in 5.7.4, 7.1.1, 6.4.1 | Affected versions of acorn are vulnerable to Regular Expression Denial of Service. A regex in the form of /[x-\\ud800]/u causes the parser to enter an infinite loop. The string is not valid UTF16 which usually results in it being sanitized before reaching the parser. If an application processes untrusted input and passes it directly to acorn, attackers may leverage the vulnerability leading to Denial of Service.
high | license/package-lock.json | semver | [CVE-2022-25883](https://nvd.nist.gov/vuln/detail/CVE-2022-25883) | 7.5 | fixed in 7.5.2 | Versions of the package semver before 7.5.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.\r\r\r
high | license/package-lock.json | ejs | [CVE-2017-1000189](https://nvd.nist.gov/vuln/detail/CVE-2017-1000189) | 7.5 | fixed in 2.5.5 | nodejs ejs version older than 2.5.5 is vulnerable to a denial-of-service due to weak input validation in the ejs.renderFile()
high | license/package-lock.json | adm-zip | [PRISMA-2021-0034]() | 0.0 | fixed in 0.5.3 | adm-zip package versions before 0.5.3 are vulnerable to Directory Traversal. It could extract files outside the target folder. origin: https://github.com/cthackers/adm-zip/commit/119dcad6599adccc77982feb14a0c7440fa63013
high | license/package-lock.json | jszip | [CVE-2022-48285](https://nvd.nist.gov/vuln/detail/CVE-2022-48285) | 7.3 | fixed in 3.8.0 | loadAsync in JSZip before 3.8.0 allows Directory Traversal via a crafted ZIP archive.
high | license/package-lock.json | degenerator | [CVE-2021-23406](https://nvd.nist.gov/vuln/detail/CVE-2021-23406) | 8.1 | fixed in 3.0.1 | This affects the package pac-resolver before 5.0.0. This can occur when used with untrusted input, due to unsafe PAC file handling. **NOTE:** The fix for this vulnerability is applied in the node-degenerator library, a dependency written by the same maintainer.
high | license/package-lock.json | lodash | [CVE-2020-8203](https://nvd.nist.gov/vuln/detail/CVE-2020-8203) | 7.4 | fixed in 4.17.20 | Prototype pollution attack when using _.zipObjectDeep in lodash before 4.17.20.
high | license/package-lock.json | lodash | [CVE-2021-23337](https://nvd.nist.gov/vuln/detail/CVE-2021-23337) | 7.2 | fixed in 4.17.21 | Lodash versions prior to 4.17.21 are vulnerable to Command Injection via the template function.
high | license/package-lock.json | mquery | [PRISMA-2021-0060](https://github.com/aheckmann/mquery/pull/121) | 0.0 | fixed in 3.2.5 | mquery package versions before 3.2.5 are vulnerable to Prototype Pollution in its exported functions cloneObject() and merge() and readily present protection by checking the key in var specialProperties = [\'__proto__\', \'constructor\', \'prototype\']. However, the current protection misses to protect another exported function mergeClone().
high | license/package-lock.json | minimatch | [CVE-2022-3517](https://nvd.nist.gov/vuln/detail/CVE-2022-3517) | 7.5 | fixed in 3.0.5 | A vulnerability was found in the minimatch package. This flaw allows a Regular Expression Denial of Service (ReDoS) when calling the braceExpand function with specific arguments, resulting in a Denial of Service.
high | license/package-lock.json | parse-url | [PRISMA-2022-0361](https://github.com/IonicaBizau/parse-url/pull/48) | 9.3 | fixed in 8.0.0 | parse-url package versions before 8.0.0 are vulnerable to Protocol Spoofing. The package misinterprets the file:// protocol when trying to match git URLs. It could be manipulated for other attacks, such as XSS, Arbitrary Read/Write Files, and Remote Code Execution.
high | license/package-lock.json | parse-url | [CVE-2022-0722](https://nvd.nist.gov/vuln/detail/CVE-2022-0722) | 7.5 | fixed in 6.0.1 | Exposure of Sensitive Information to an Unauthorized Actor in GitHub repository ionicabizau/parse-url prior to 7.0.0.
high | license/package-lock.json | nconf | [CVE-2022-21803](https://nvd.nist.gov/vuln/detail/CVE-2022-21803) | 7.5 | fixed in 0.11.4 | This affects the package nconf before 0.11.4. When using the memory engine, it is possible to store a nested JSON representation of the configuration. The .set() function, that is responsible for setting the configuration properties, is vulnerable to Prototype Pollution. By providing a crafted property, it is possible to modify the properties on the Object.prototype.
high | license/package-lock.json | fresh | [CVE-2017-16119](https://nvd.nist.gov/vuln/detail/CVE-2017-16119) | 7.5 | fixed in 0.5.2 | Fresh is a module used by the Express.js framework for HTTP response freshness testing. It is vulnerable to a regular expression denial of service when it is passed specially crafted input to parse. This causes the event loop to be blocked causing a denial of service condition.
high | license/package-lock.json | path-parse | [CVE-2021-23343](https://nvd.nist.gov/vuln/detail/CVE-2021-23343) | 7.5 | fixed in 1.0.7 | All versions of package path-parse are vulnerable to Regular Expression Denial of Service (ReDoS) via splitDeviceRe, splitTailRe, and splitPathRe regular expressions. ReDoS exhibits polynomial worst-case time complexity.
high | license/package-lock.json | mongoose | [PRISMA-2021-0067](https://github.com/Automattic/mongoose/issues/10035) | 0.0 | fixed in 5.12.2 | mongoose package versions  before 5.12.2 are vulnerable to Prototype pollution at mongoose.Schema() due to the recursively calling of Schema.prototype.add() function to add new items into the schema object. It\'s allows modification of the Object prototype.
high | license/package-lock.json | express-fileupload | [PRISMA-2022-0323](https://github.com/richardgirges/express-fileupload/issues/83) | 7.5 | fixed in 1.0.0 | express-fileupload package versions before 1.0.0-alpha.1 is vulnerable to Denial of Service (DoS) due to md5(buf) resulting in a JavaScript heap out of memory (happened when uploading 100M+ files).
high | license/package-lock.json | express-fileupload | [PRISMA-2022-0318](https://github.com/richardgirges/express-fileupload/pull/171) | 7.5 | fixed in 1.1.6-alpha.6 | express-fileupload package versions before 1.1.6-alpha.6 are vulnerable to Regular Expression Denial of Service (ReDoS) due to a lack of limit file name length.
high | license/package-lock.json | dot-prop | [CVE-2020-8116](https://nvd.nist.gov/vuln/detail/CVE-2020-8116) | 7.3 | fixed in 5.1.1, 4.2.1 | Prototype pollution vulnerability in dot-prop npm package versions before 4.2.1 and versions 5.x before 5.1.1 allows an attacker to add arbitrary properties to JavaScript language constructs such as objects.
high | license/package-lock.json | browserify-sign | [CVE-2023-46234](https://nvd.nist.gov/vuln/detail/CVE-2023-46234) | 7.5 | fixed in 4.2.2 | browserify-sign is a package to duplicate the functionality of node\'s crypto public key functions, much of this is based on Fedor Indutny\'s work on indutny/tls.js. An upper bound check issue in `dsaVerify` function allows an attacker to construct signatures that can be successfully verified by any public key, thus leading to a signature forgery attack. All places in this project that involve DSA verification of user-input signatures will be affected by this vulnerability. This issue has been patched in version 4.2.2. 
high | license/package-lock.json | dustjs-linkedin | [CVE-2021-4264](https://nvd.nist.gov/vuln/detail/CVE-2021-4264) | 8.8 | fixed in 3.0.0 | A vulnerability was found in LinkedIn dustjs up to 2.x and classified as problematic. Affected by this issue is some unknown functionality. The manipulation leads to improperly controlled modification of object prototype attributes (\'prototype pollution\'). The attack may be launched remotely. The exploit has been disclosed to the public and may be used. Upgrading to version 3.0.0 is able to address this issue. The name of the patch is ddb6523832465d38c9d80189e9de60519ac307c3. It is recommended to upgrade the affected component. The identifier of this vulnerability is VDB-216464.
high | license/package-lock.json | moment | [CVE-2017-18214](https://nvd.nist.gov/vuln/detail/CVE-2017-18214) | 7.5 | fixed in 2.19.3 | The moment module before 2.19.3 for Node.js is prone to a regular expression denial of service via a crafted date string, a different vulnerability than CVE-2016-4055.
high | license/package-lock.json | moment | [CVE-2022-24785](https://nvd.nist.gov/vuln/detail/CVE-2022-24785) | 7.5 | fixed in 2.29.2 | Moment.js is a JavaScript date library for parsing, validating, manipulating, and formatting dates. A path traversal vulnerability impacts npm (server) users of Moment.js between versions 1.0.1 and 2.29.1, especially if a user-provided locale string is directly used to switch moment locale. This problem is patched in 2.29.2, and the patch can be applied to all affected versions. As a workaround, sanitize the user-provided locale name before passing it to Moment.js.
high | license/package-lock.json | kerberos | [CVE-2020-13110](https://nvd.nist.gov/vuln/detail/CVE-2020-13110) | 7.8 | fixed in 1.0.0 | The kerberos package before 1.0.0 for Node.js allows arbitrary code execution and privilege escalation via injection of malicious DLLs through use of the kerberos_sspi LoadLibrary() method, because of a DLL path search.
high | license/package-lock.json | snyk-go-plugin | [CVE-2022-40764](https://nvd.nist.gov/vuln/detail/CVE-2022-40764) | 7.8 | fixed in 1.19.1 | Snyk CLI before 1.996.0 allows arbitrary command execution, affecting Snyk IDE plugins and the snyk npm package. Exploitation could follow from the common practice of viewing untrusted files in the Visual Studio Code editor, for example. The original demonstration was with shell metacharacters in the vendor.json ignore field, affecting snyk-go-plugin before 1.19.1. This affects, for example, the Snyk TeamCity plugin (which does not update automatically) before 20220930.142957.
high | app/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2022-42004](https://nvd.nist.gov/vuln/detail/CVE-2022-42004) | 7.5 | fixed in 2.13.4 | In FasterXML jackson-databind before 2.13.4, resource exhaustion can occur because of a lack of a check in BeanDeserializer._deserializeFromArray to prevent use of deeply nested arrays. An application is vulnerable only with certain customized choices for deserialization.
high | app/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-25649](https://nvd.nist.gov/vuln/detail/CVE-2020-25649) | 7.5 | fixed in 2.10.5.1, 2.9.10.7, 2.6.7.4 | A flaw was found in FasterXML Jackson Databind, where it did not have entity expansion secured properly. This flaw allows vulnerability to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.
high | app/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) | 7.5 | fixed in 2.12.6.1, 2.13.2.1 | jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.
high | app/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2021-46877](https://nvd.nist.gov/vuln/detail/CVE-2021-46877) | 7.5 | fixed in 2.13.1, 2.12.6 | jackson-databind 2.10.x through 2.12.x before 2.12.6 and 2.13.x before 2.13.1 allows attackers to cause a denial of service (2 GB transient heap usage per read) in uncommon situations involving JsonNode JDK serialization.
high | app/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003) | 7.5 | fixed in 2.13.4.1, 2.12.7.1 | In FasterXML jackson-databind before versions 2.13.4.1 and 2.12.17.1, resource exhaustion can occur because of a lack of a check in primitive value deserializers to avoid deep wrapper array nesting, when the UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled.
moderate | license/package-lock.json | npmconf | [GHSA-57cf-349j-352g](https://github.com/advisories/GHSA-57cf-349j-352g) | 4.0 | fixed in 2.1.3 | Versions of `npmconf` before 2.1.3 allocate and write to disk uninitialized memory contents when a typed number is passed as input on Node.js 4.x.   ## Recommendation  Update to version 2.1.3 or later. Consider switching to another config storage mechanism, as npmconf is deprecated and should not be used.
medium | license/package-lock.json | marked | [PRISMA-2021-0013]() | 0.0 | fixed in 1.1.1 | marked package prior to 1.1.1 are vulnerable to  Regular Expression Denial of Service (ReDoS). The regex within src/rules.js file have multiple unused capture groups which could lead to a denial of service attack if user input is reachable.  Origin: https://github.com/markedjs/marked/commit/bd4f8c464befad2b304d51e33e89e567326e62e0
moderate | license/package-lock.json | marked | [CVE-2017-1000427](https://nvd.nist.gov/vuln/detail/CVE-2017-1000427) | 6.1 | fixed in 0.3.7 | marked version 0.3.6 and earlier is vulnerable to an XSS attack in the data: URI parser.
moderate | license/package-lock.json | highlight.js | [GHSA-7wwv-vh3v-89cq](https://github.com/advisories/GHSA-7wwv-vh3v-89cq) | 4.0 | fixed in 10.4.1 | ### Impact: Potential ReDOS vulnerabilities (exponential and polynomial RegEx backtracking)  [oswasp](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS):   > The Regular expression Denial of Service (ReDoS) is a Denial of Service attack, that exploits the fact that most Regular Expression implementations may reach extreme situations that cause them to work very slowly (exponentially related to input size). An attacker can then cause a program using a Regular Expression to enter these extreme situations and then hang for a very long time.  If are you are using Highlight.js to highlight user-provided data you are possibly vulnerable.  On the client-side (in a browser or Electron environment) risks could include lengthy freezes or crashes... On the server-side infinite freezes could occur... effectively preventing users from accessing your app or service (ie, Denial of Service).  This is an issue with grammars shipped with the parser (and potentially 3rd party grammars also), not the parser itself. If you are using Highlight.js with any of the following grammars you are vulnerable.  If you are using `highlightAuto` to detect the language (and have any of these grammars registered) you are vulnerable. Exponential grammars (C, Perl, JavaScript) are auto-registered when using the common grammar subset/library `require(\'highlight.js/lib/common\')` as 
moderate | license/package-lock.json | snyk | [CVE-2022-22984](https://nvd.nist.gov/vuln/detail/CVE-2022-22984) | 6.3 | fixed in 1.1064.0 | The package snyk before 1.1064.0; the package snyk-mvn-plugin before 2.31.3; the package snyk-gradle-plugin before 3.24.5; the package @snyk/snyk-cocoapods-plugin before 2.5.3; the package snyk-sbt-plugin before 2.16.2; the package snyk-python-plugin before 1.24.2; the package snyk-docker-plugin before 5.6.5; the package @snyk/snyk-hex-plugin before 1.1.6 are vulnerable to Command Injection due to an incomplete fix for [CVE-2022-40764](https://security.snyk.io/vuln/SNYK-JS-SNYK-3037342). A successful exploit allows attackers to run arbitrary commands on the host system where the Snyk CLI is installed by passing in crafted command line flags. In order to exploit this vulnerability, a user would have to execute the snyk test command on untrusted files. In most cases, an attacker positioned to control the command line arguments to the Snyk CLI would already be positioned to execute arbitrary commands. However, this could be abused in specific scenarios, such as continuous integration pipelines, where developers can control the arguments passed to the Snyk CLI to leverage this component as part of a wider attack against an integration/build pipeline. This issue has been addressed in the latest Snyk Docker images available at https://hub.docker.com/r/snyk/snyk as of 2022-11-29. Images downloaded and built prior to that date should be updated. The issue has also been addressed in the
moderate | license/package-lock.json | xml2js | [CVE-2023-0842](https://nvd.nist.gov/vuln/detail/CVE-2023-0842) | 5.3 | fixed in 0.5.0 | xml2js version 0.4.23 allows an external attacker to edit or add new properties to an object. This is possible because the application does not properly validate incoming JSON keys, thus allowing the __proto__ property to be edited.
medium | license/package-lock.json | tap-mocha-reporter | [PRISMA-2022-0097](https://github.com/tapjs/tap-mocha-reporter/commit/50c8c31ed7f6ebf18de4339ee0e64b1558b07e83) | 5.3 | fixed in 5.0.2 | tap-mocha-reporter package versions before 5.0.2 are vulnerable to Regular Expression Denial of Service (ReDoS) due to vulnerable return value.
moderate | license/package-lock.json | snyk-python-plugin | [CVE-2022-22984](https://nvd.nist.gov/vuln/detail/CVE-2022-22984) | 6.3 | fixed in 1.24.2 | The package snyk before 1.1064.0; the package snyk-mvn-plugin before 2.31.3; the package snyk-gradle-plugin before 3.24.5; the package @snyk/snyk-cocoapods-plugin before 2.5.3; the package snyk-sbt-plugin before 2.16.2; the package snyk-python-plugin before 1.24.2; the package snyk-docker-plugin before 5.6.5; the package @snyk/snyk-hex-plugin before 1.1.6 are vulnerable to Command Injection due to an incomplete fix for [CVE-2022-40764](https://security.snyk.io/vuln/SNYK-JS-SNYK-3037342). A successful exploit allows attackers to run arbitrary commands on the host system where the Snyk CLI is installed by passing in crafted command line flags. In order to exploit this vulnerability, a user would have to execute the snyk test command on untrusted files. In most cases, an attacker positioned to control the command line arguments to the Snyk CLI would already be positioned to execute arbitrary commands. However, this could be abused in specific scenarios, such as continuous integration pipelines, where developers can control the arguments passed to the Snyk CLI to leverage this component as part of a wider attack against an integration/build pipeline. This issue has been addressed in the latest Snyk Docker images available at https://hub.docker.com/r/snyk/snyk as of 2022-11-29. Images downloaded and built prior to that date should be updated. The issue has also been addressed in the
medium | license/package-lock.json | got | [CVE-2022-33987](https://nvd.nist.gov/vuln/detail/CVE-2022-33987) | 5.3 | fixed in 12.1.0 | The got package before 12.1.0 (also fixed in 11.8.5) for Node.js allows a redirect to a UNIX socket.
moderate | license/package-lock.json | bl | [CVE-2020-8244](https://nvd.nist.gov/vuln/detail/CVE-2020-8244) | 6.5 | fixed in 2.2.1, 1.2.3, 4.0.3, 3.0.1 | A buffer over-read vulnerability exists in bl <4.0.3, <3.0.1, <2.2.1, and <1.2.3 which could allow an attacker to supply user input (even typed) that if it ends up in consume() argument and can become negative, the BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular .slice() calls.
medium | license/package-lock.json | ms | [CVE-2017-20162](https://nvd.nist.gov/vuln/detail/CVE-2017-20162) | 5.3 | fixed in 2.0.0 | A vulnerability, which was classified as problematic, has been found in vercel ms up to 1.x. This issue affects the function parse of the file index.js. The manipulation of the argument str leads to inefficient regular expression complexity. The attack may be initiated remotely. The exploit has been disclosed to the public and may be used. Upgrading to version 2.0.0 is able to address this issue. The patch is named caae2988ba2a37765d055c4eee63d383320ee662. It is recommended to upgrade the affected component. The associated identifier of this vulnerability is VDB-217451.
medium | license/package-lock.json | elliptic | [CVE-2020-28498](https://nvd.nist.gov/vuln/detail/CVE-2020-28498) | 6.8 | fixed in 6.5.4 | The package elliptic before 6.5.4 are vulnerable to Cryptographic Issues via the secp256k1 implementation in elliptic/ec/key.js. There is no check to confirm that the public key point passed into the derive function actually exists on the secp256k1 curve. This results in the potential for the private key used in this implementation to be revealed after a number of ECDH operations are performed.
moderate | license/package-lock.json | ajv | [CVE-2020-15366](https://nvd.nist.gov/vuln/detail/CVE-2020-15366) | 5.6 | fixed in 6.12.3 | An issue was discovered in ajv.validate() in Ajv (aka Another JSON Schema Validator) 6.12.2. A carefully crafted JSON schema could be provided that allows execution of other code by prototype pollution. (While untrusted schemas are recommended against, the worst case of an untrusted schema should be a denial of service, not execution of code.)
moderate | license/package-lock.json | ejs | [CVE-2017-1000188](https://nvd.nist.gov/vuln/detail/CVE-2017-1000188) | 6.1 | fixed in 2.5.5 | nodejs ejs version older than 2.5.5 is vulnerable to a Cross-site-scripting in the ejs.renderFile() resulting in code injection
medium | license/package-lock.json | adm-zip | [CVE-2018-1002204](https://nvd.nist.gov/vuln/detail/CVE-2018-1002204) | 5.5 | fixed in 0.4.9 | adm-zip npm library before 0.4.9 is vulnerable to directory traversal, allowing attackers to write to arbitrary files via a ../ (dot dot slash) in a Zip archive entry that is mishandled during extraction. This vulnerability is also known as \'Zip-Slip\'.
medium | license/package-lock.json | jszip | [CVE-2021-23413](https://nvd.nist.gov/vuln/detail/CVE-2021-23413) | 5.3 | fixed in 3.7.0 | This affects the package jszip before 3.7.0. Crafting a new zip file with filenames set to Object prototype values (e.g __proto__, toString, etc) results in a returned object with a modified prototype instance.
moderate | license/package-lock.json | snyk-docker-plugin | [CVE-2022-22984](https://nvd.nist.gov/vuln/detail/CVE-2022-22984) | 6.3 | fixed in 5.6.5 | The package snyk before 1.1064.0; the package snyk-mvn-plugin before 2.31.3; the package snyk-gradle-plugin before 3.24.5; the package @snyk/snyk-cocoapods-plugin before 2.5.3; the package snyk-sbt-plugin before 2.16.2; the package snyk-python-plugin before 1.24.2; the package snyk-docker-plugin before 5.6.5; the package @snyk/snyk-hex-plugin before 1.1.6 are vulnerable to Command Injection due to an incomplete fix for [CVE-2022-40764](https://security.snyk.io/vuln/SNYK-JS-SNYK-3037342). A successful exploit allows attackers to run arbitrary commands on the host system where the Snyk CLI is installed by passing in crafted command line flags. In order to exploit this vulnerability, a user would have to execute the snyk test command on untrusted files. In most cases, an attacker positioned to control the command line arguments to the Snyk CLI would already be positioned to execute arbitrary commands. However, this could be abused in specific scenarios, such as continuous integration pipelines, where developers can control the arguments passed to the Snyk CLI to leverage this component as part of a wider attack against an integration/build pipeline. This issue has been addressed in the latest Snyk Docker images available at https://hub.docker.com/r/snyk/snyk as of 2022-11-29. Images downloaded and built prior to that date should be updated. The issue has also been addressed in the
medium | license/package-lock.json | minimist | [CVE-2020-7598](https://nvd.nist.gov/vuln/detail/CVE-2020-7598) | 5.6 | fixed in 1.2.2 | minimist before 1.2.2 could be tricked into adding or modifying properties of Object.prototype using a \"constructor\" or \"__proto__\" payload.
medium | license/package-lock.json | lodash | [CVE-2018-16487](https://nvd.nist.gov/vuln/detail/CVE-2018-16487) | 5.6 | fixed in 4.17.11 | A prototype pollution vulnerability was found in lodash <4.17.11 where the functions merge, mergeWith, and defaultsDeep can be tricked into adding or modifying properties of Object.prototype.
medium | license/package-lock.json | lodash | [CVE-2018-3721](https://nvd.nist.gov/vuln/detail/CVE-2018-3721) | 6.5 | fixed in 4.17.5 | lodash node module before 4.17.5 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability via defaultsDeep, merge, and mergeWith functions, which allows a malicious user to modify the prototype of \"Object\" via __proto__, causing the addition or modification of an existing property that will exist on all objects.
medium | license/package-lock.json | lodash | [CVE-2019-1010266](https://nvd.nist.gov/vuln/detail/CVE-2019-1010266) | 6.5 | fixed in 4.17.11 | lodash prior to 4.17.11 is affected by: CWE-400: Uncontrolled Resource Consumption. The impact is: Denial of service. The component is: Date handler. The attack vector is: Attacker provides very long strings, which the library attempts to match using a regular expression. The fixed version is: 4.17.11.
medium | license/package-lock.json | lodash | [CVE-2020-28500](https://nvd.nist.gov/vuln/detail/CVE-2020-28500) | 5.3 | fixed in 4.17.21 | Lodash versions prior to 4.17.21 are vulnerable to Regular Expression Denial of Service (ReDoS) via the toNumber, trim and trimEnd functions.
medium | license/package-lock.json | mquery | [CVE-2020-35149](https://nvd.nist.gov/vuln/detail/CVE-2020-35149) | 5.3 | fixed in 3.2.3 | lib/utils.js in mquery before 3.2.3 allows a pollution attack because a special property (e.g., __proto__) can be copied during a merge or clone operation.
moderate | license/package-lock.json | snyk-gradle-plugin | [CVE-2022-22984](https://nvd.nist.gov/vuln/detail/CVE-2022-22984) | 6.3 | fixed in 3.24.5 | The package snyk before 1.1064.0; the package snyk-mvn-plugin before 2.31.3; the package snyk-gradle-plugin before 3.24.5; the package @snyk/snyk-cocoapods-plugin before 2.5.3; the package snyk-sbt-plugin before 2.16.2; the package snyk-python-plugin before 1.24.2; the package snyk-docker-plugin before 5.6.5; the package @snyk/snyk-hex-plugin before 1.1.6 are vulnerable to Command Injection due to an incomplete fix for [CVE-2022-40764](https://security.snyk.io/vuln/SNYK-JS-SNYK-3037342). A successful exploit allows attackers to run arbitrary commands on the host system where the Snyk CLI is installed by passing in crafted command line flags. In order to exploit this vulnerability, a user would have to execute the snyk test command on untrusted files. In most cases, an attacker positioned to control the command line arguments to the Snyk CLI would already be positioned to execute arbitrary commands. However, this could be abused in specific scenarios, such as continuous integration pipelines, where developers can control the arguments passed to the Snyk CLI to leverage this component as part of a wider attack against an integration/build pipeline. This issue has been addressed in the latest Snyk Docker images available at https://hub.docker.com/r/snyk/snyk as of 2022-11-29. Images downloaded and built prior to that date should be updated. The issue has also been addressed in the
moderate | license/package-lock.json | parse-url | [CVE-2022-3224](https://nvd.nist.gov/vuln/detail/CVE-2022-3224) | 6.1 | fixed in 8.1.0 | Misinterpretation of Input in GitHub repository ionicabizau/parse-url prior to 8.1.0.
moderate | license/package-lock.json | parse-url | [CVE-2022-2217](https://nvd.nist.gov/vuln/detail/CVE-2022-2217) | 6.1 | fixed in 6.0.1 | Cross-site Scripting (XSS) - Generic in GitHub repository ionicabizau/parse-url prior to 7.0.0.
moderate | license/package-lock.json | parse-url | [CVE-2022-2218](https://nvd.nist.gov/vuln/detail/CVE-2022-2218) | 6.1 | fixed in 6.0.1 | Cross-site Scripting (XSS) - Stored in GitHub repository ionicabizau/parse-url prior to 7.0.0.
moderate | license/package-lock.json | @snyk/snyk-cocoapods-plugin | [CVE-2022-22984](https://nvd.nist.gov/vuln/detail/CVE-2022-22984) | 6.3 | fixed in 2.5.3 | The package snyk before 1.1064.0; the package snyk-mvn-plugin before 2.31.3; the package snyk-gradle-plugin before 3.24.5; the package @snyk/snyk-cocoapods-plugin before 2.5.3; the package snyk-sbt-plugin before 2.16.2; the package snyk-python-plugin before 1.24.2; the package snyk-docker-plugin before 5.6.5; the package @snyk/snyk-hex-plugin before 1.1.6 are vulnerable to Command Injection due to an incomplete fix for [CVE-2022-40764](https://security.snyk.io/vuln/SNYK-JS-SNYK-3037342). A successful exploit allows attackers to run arbitrary commands on the host system where the Snyk CLI is installed by passing in crafted command line flags. In order to exploit this vulnerability, a user would have to execute the snyk test command on untrusted files. In most cases, an attacker positioned to control the command line arguments to the Snyk CLI would already be positioned to execute arbitrary commands. However, this could be abused in specific scenarios, such as continuous integration pipelines, where developers can control the arguments passed to the Snyk CLI to leverage this component as part of a wider attack against an integration/build pipeline. This issue has been addressed in the latest Snyk Docker images available at https://hub.docker.com/r/snyk/snyk as of 2022-11-29. Images downloaded and built prior to that date should be updated. The issue has also been addressed in the
medium | license/package-lock.json | file-type | [CVE-2022-36313](https://nvd.nist.gov/vuln/detail/CVE-2022-36313) | 5.5 | fixed in 17.1.3, 16.5.4 | An issue was discovered in the file-type package before 16.5.4 and 17.x before 17.1.3 for Node.js. A malformed MKV file could cause the file type detector to get caught in an infinite loop. This would make the application become unresponsive and could be used to cause a DoS attack.
medium | license/package-lock.json | netmask | [CVE-2021-29418](https://nvd.nist.gov/vuln/detail/CVE-2021-29418) | 5.3 | fixed in 2.0.1 | The netmask package before 2.0.1 for Node.js mishandles certain unexpected characters in an IP address string, such as an octal digit of 9. This (in some situations) allows attackers to bypass access control that is based on IP addresses. NOTE: this issue exists because of an incomplete fix for CVE-2021-28918.
moderate | license/package-lock.json | snyk-mvn-plugin | [CVE-2022-22984](https://nvd.nist.gov/vuln/detail/CVE-2022-22984) | 6.3 | fixed in 2.31.3 | The package snyk before 1.1064.0; the package snyk-mvn-plugin before 2.31.3; the package snyk-gradle-plugin before 3.24.5; the package @snyk/snyk-cocoapods-plugin before 2.5.3; the package snyk-sbt-plugin before 2.16.2; the package snyk-python-plugin before 1.24.2; the package snyk-docker-plugin before 5.6.5; the package @snyk/snyk-hex-plugin before 1.1.6 are vulnerable to Command Injection due to an incomplete fix for [CVE-2022-40764](https://security.snyk.io/vuln/SNYK-JS-SNYK-3037342). A successful exploit allows attackers to run arbitrary commands on the host system where the Snyk CLI is installed by passing in crafted command line flags. In order to exploit this vulnerability, a user would have to execute the snyk test command on untrusted files. In most cases, an attacker positioned to control the command line arguments to the Snyk CLI would already be positioned to execute arbitrary commands. However, this could be abused in specific scenarios, such as continuous integration pipelines, where developers can control the arguments passed to the Snyk CLI to leverage this component as part of a wider attack against an integration/build pipeline. This issue has been addressed in the latest Snyk Docker images available at https://hub.docker.com/r/snyk/snyk as of 2022-11-29. Images downloaded and built prior to that date should be updated. The issue has also been addressed in the
moderate | license/package-lock.json | mongoose | [GHSA-r5xw-q988-826m](https://github.com/advisories/GHSA-r5xw-q988-826m) | 5.1 | fixed in 4.3.6, 3.8.39 | Versions of `mongoose` before 4.3.6, 3.8.39 are vulnerable to remote memory exposure.  Trying to save a number to a field of type Buffer on the affected mongoose versions allocates a chunk of uninitialized memory and stores it in the database.   ## Recommendation  Update to version 4.3.6, 3.8.39 or later.
medium | license/package-lock.json | cookie-signature | [CVE-2016-1000236](https://nvd.nist.gov/vuln/detail/CVE-2016-1000236) | 4.4 | fixed in 1.0.6 | Node-cookie-signature before 1.0.6 is affected by a timing attack due to the type of comparison used.
moderate | license/package-lock.json | bson | [CVE-2019-2391](https://nvd.nist.gov/vuln/detail/CVE-2019-2391) | 5.4 | fixed in 1.1.4 | Incorrect parsing of certain JSON input may result in js-bson not correctly serializing BSON. This may cause unexpected application behaviour including data disclosure. This issue affects: MongoDB Inc. js-bson library version 1.1.3 and prior to.  
moderate | license/package-lock.json | snyk-sbt-plugin | [CVE-2022-22984](https://nvd.nist.gov/vuln/detail/CVE-2022-22984) | 6.3 | fixed in 2.16.2 | The package snyk before 1.1064.0; the package snyk-mvn-plugin before 2.31.3; the package snyk-gradle-plugin before 3.24.5; the package @snyk/snyk-cocoapods-plugin before 2.5.3; the package snyk-sbt-plugin before 2.16.2; the package snyk-python-plugin before 1.24.2; the package snyk-docker-plugin before 5.6.5; the package @snyk/snyk-hex-plugin before 1.1.6 are vulnerable to Command Injection due to an incomplete fix for [CVE-2022-40764](https://security.snyk.io/vuln/SNYK-JS-SNYK-3037342). A successful exploit allows attackers to run arbitrary commands on the host system where the Snyk CLI is installed by passing in crafted command line flags. In order to exploit this vulnerability, a user would have to execute the snyk test command on untrusted files. In most cases, an attacker positioned to control the command line arguments to the Snyk CLI would already be positioned to execute arbitrary commands. However, this could be abused in specific scenarios, such as continuous integration pipelines, where developers can control the arguments passed to the Snyk CLI to leverage this component as part of a wider attack against an integration/build pipeline. This issue has been addressed in the latest Snyk Docker images available at https://hub.docker.com/r/snyk/snyk as of 2022-11-29. Images downloaded and built prior to that date should be updated. The issue has also been addressed in the
medium | license/package-lock.json | parse-path | [CVE-2022-0624](https://github.com/ionicabizau/parse-path/commit/f9ad8856a3c8ae18e1cf4caef5edbabbc42840e8) | 6.5 | fixed in 5.0.0 | Authorization Bypass Through User-Controlled Key in GitHub repository ionicabizau/parse-path prior to 5.0.0.
moderate | license/package-lock.json | hosted-git-info | [CVE-2021-23362](https://nvd.nist.gov/vuln/detail/CVE-2021-23362) | 5.3 | fixed in 2.8.9, 3.0.8 | The package hosted-git-info before 3.0.8 are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression shortcutMatch in the fromUrl function in index.js. The affected regular expression exhibits polynomial worst-case time complexity.
moderate | license/package-lock.json | jquery | [CVE-2020-11022](https://nvd.nist.gov/vuln/detail/CVE-2020-11022) | 6.9 | fixed in 3.5.0 | In jQuery versions greater than or equal to 1.2 and before 3.5.0, passing HTML from untrusted sources - even after sanitizing it - to one of jQuery\'s DOM manipulation methods (i.e. .html(), .append(), and others) may execute untrusted code. This problem is patched in jQuery 3.5.0.
moderate | license/package-lock.json | jquery | [CVE-2020-11023](https://nvd.nist.gov/vuln/detail/CVE-2020-11023) | 6.9 | fixed in 3.5.0 | In jQuery versions greater than or equal to 1.0.3 and before 3.5.0, passing HTML containing <option> elements from untrusted sources - even after sanitizing it - to one of jQuery\'s DOM manipulation methods (i.e. .html(), .append(), and others) may execute untrusted code. This problem is patched in jQuery 3.5.0.
moderate | license/package-lock.json | jquery | [CVE-2020-23064](https://nvd.nist.gov/vuln/detail/CVE-2020-23064) | 6.1 | fixed in 3.5.0 | Cross Site Scripting vulnerability in jQuery 2.2.0 through 3.x before 3.5.0 allows a remote attacker to execute arbitrary code via the <options> element.
moderate | license/package-lock.json | jquery | [CVE-2019-11358](https://nvd.nist.gov/vuln/detail/CVE-2019-11358) | 6.1 | fixed in 3.4.0 | jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of Object.prototype pollution. If an unsanitized source object contained an enumerable __proto__ property, it could extend the native Object.prototype.
moderate | license/package-lock.json | jquery | [CVE-2015-9251](https://nvd.nist.gov/vuln/detail/CVE-2015-9251) | 6.1 | fixed in 3.0.0, 1.12.2 | jQuery before 3.0.0 is vulnerable to Cross-site Scripting (XSS) attacks when a cross-domain Ajax request is performed without the dataType option, causing text/javascript responses to be executed.
medium | app/pom.xml | com.fasterxml.jackson.core_jackson-databind | [CVE-2023-35116](https://nvd.nist.gov/vuln/detail/CVE-2023-35116) | 4.7 | fixed in 2.16.0 | jackson-databind through 2.15.2 allows attackers to cause a denial of service or other unspecified impact via a crafted object that uses cyclic dependencies. NOTE: the vendor\'s perspective is that this is not a valid vulnerability report, because the steps of constructing a cyclic data structure and trying to serialize it cannot be achieved by an external attacker.
low | license/package-lock.json | express-fileupload | [GHSA-q3w9-g74q-vp5f](https://github.com/advisories/GHSA-q3w9-g74q-vp5f) | 1.0 | fixed in 1.1.6-alpha.6, 1.1.6-alpha.6, 1.1.6-alpha.6, 1.1.6-alpha.6, 1.1.6-alpha.6 | Versions of `express-fileupload` prior to 1.1.6-alpha.6 are vulnerable to Denial of Service. The package causes server responses to be delayed (up to 30s in internal testing) if the request contains a large `filename` of `.` characters.     ## Recommendation  Upgrade to version 1.1.6-alpha.6 or later.
